### PR TITLE
Include https://github.com/puppetlabs/puppetdb/pull/3203 patch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppetdb (2.3.8-1puppetlabs1+xenial0+exo6) xenial; urgency=low
+
+  * Include https://github.com/puppetlabs/puppetdb/pull/3203 patch
+
+ -- Cédric Dufour <cedric.dufour@exoscale.ch>  Tue, 24 Mar 2020 18:03:40 +0100
+
 puppetdb (2.3.8-1puppetlabs1+xenial0+exo5) xenial; urgency=medium
 
   * Automatically restart on failure.


### PR DESCRIPTION
# Description

[ch11243]

## Testing done:

**unit tests:**
See https://app.clubhouse.io/exoscale/story/11414/run-puppetdb-unit-tests

**re-packaging:**
```
* cdufour@xps13-9380.cedric.exoscale.me:~/github/exoscale/pkg-puppetdb/test (xenial)
$ tar -C orig -xaf ../puppetdb_2.3.8.orig.tar.gz puppetdb-2.3.8/puppetdb.jar --strip-components=1

$ unzip -q -d orig/puppetdb.jar.d/ orig/puppetdb.jar

$ git checkout cedric/patch-upstream-PR-3203 
Switched to branch 'cedric/patch-upstream-PR-3203'
Your branch is up to date with 'exoscale/cedric/patch-upstream-PR-3203'.

* cdufour@xps13-9380.cedric.exoscale.me:~/github/exoscale/pkg-puppetdb/test (cedric/patch-upstream-PR-3203)
$ tar -C patched -xaf ../puppetdb_2.3.8.orig.tar.gz puppetdb-2.3.8/puppetdb.jar --strip-components=1

$ unzip -q -d patched/puppetdb.jar.d/ patched/puppetdb.jar

$ jardiff -o text -f orig/puppetdb.jar -t patched/puppetdb.jar
Comparing puppetdb.jar to puppetdb.jar
API diff generated by JarDiff http://www.osjava.org/jardiff/

$ diff -urN orig/puppetdb.jar.d/ patched/puppetdb.jar.d/
diff -urN orig/puppetdb.jar.d/com/puppetlabs/puppetdb/query.clj patched/puppetdb.jar.d/com/puppetlabs/puppetdb/query.clj
--- orig/puppetdb.jar.d/com/puppetlabs/puppetdb/query.clj	2015-10-13 15:23:24.000000000 +0200
+++ patched/puppetdb.jar.d/com/puppetlabs/puppetdb/query.clj	2020-03-24 16:56:58.000000000 +0100
@@ -354,7 +354,7 @@
       (throw (IllegalArgumentException. (format "The argument to extract must be a select operator, not '%s'" (first subquery)))))
     (when-not (get (queryable-fields subquery-type query-api-version) field)
       (throw (IllegalArgumentException. (format "Can't extract unknown %s field '%s'. Acceptable fields are: %s" (name subquery-type) field (string/join ", " (sort (queryable-fields subquery-type query-api-version)))))))
-    {:where (format "SELECT r1.%s FROM (%s) r1" field subselect)
+    {:where (format "SELECT DISTINCT r1.%s FROM (%s) r1" field subselect)
      :params params}))
 
 (defn compile-in
Binary files orig/puppetdb.jar.d/riddley/.DS_Store and patched/puppetdb.jar.d/riddley/.DS_Store differ
@ 2020-03-24 18:40:29 +0100
```

**pbuilder:**
```
 ubuntu@ubuntu1804.cedric.exoscale.me:~/github/exoscale/pkg-puppetdb (cedric/patch-upstream-PR-3203)
$ pbuilder-git-build -d xenial
INFO: About to build package from branch: cedric/patch-upstream-PR-3203
INFO: Using PBuilder base: /var/cache/pbuilder/xenial-amd64/base.tgz
PRESS <ENTER> TO PROCEED, <CTRL+C> TO ABORT ...

gbp:info: Building with pbuilder for xenial:amd64
gbp:info: All Orig tarballs 'puppetdb_2.3.8.orig.tar.gz' found at '.'
gbp:info: Exporting 'HEAD' to '/home/ubuntu/github/exoscale/puppetdb-tmp'
gbp:info: Moving '/home/ubuntu/github/exoscale/puppetdb-tmp' to '/home/ubuntu/github/exoscale/puppetdb-2.3.8'
gbp:info: Performing the build
Building with pbuilder
[[ ... ]]
dpkg-deb: building package 'puppetdb' in '../puppetdb_2.3.8-1puppetlabs1+xenial0+exo6_all.deb'.
 dpkg-genchanges  >../puppetdb_2.3.8-1puppetlabs1+xenial0+exo6_amd64.changes
dpkg-genchanges: not including original source code in upload
 dpkg-source -i.*\.orig\.tar\..* --after-build puppetdb-2.3.8
dpkg-buildpackage: binary and diff upload (original source NOT included)
I: copying local configuration
I: Copying back the cached apt archive contents
I: unmounting /var/cache/pbuilder/xenial-amd64/ccache filesystem
I: unmounting dev/ptmx filesystem
I: unmounting dev/pts filesystem
I: unmounting dev/shm filesystem
I: unmounting proc filesystem
I: unmounting sys filesystem
I: cleaning the build env 
I: removing directory /var/cache/pbuilder/xenial-amd64/chroot/18644 and its subdirectories
I: Current time: Tue Mar 24 17:22:00 UTC 2020
I: pbuilder-time-stamp: 1585070520
DONE!
-rw-r--r-- 1 root root 1010 Mar 24 17:21 ../puppetdb_2.3.8-1puppetlabs1+xenial0+exo6.dsc
-rw-r--r-- 1 root root 23M Mar 24 17:21 ../puppetdb_2.3.8-1puppetlabs1+xenial0+exo6_all.deb
@ 2020-03-24 17:22:00 +0000
```