### PR TITLE
Xenial 2.3.10

### DIFF
--- a/debian/README.md
+++ b/debian/README.md
@@ -1,0 +1,11 @@
+# pkg-puppetdb
+This repository packages a puppetdb tarball as a debian package. It is used by a 'backports' jenkins job, defined in https://github.com/exoscale/jobs
+
+## Creating a new tarball
+The tarball is created from the [puppetdb repository](https://github.com/exoscale/puppetdb/tree/2.3.x). The `test` and `build` job in the `Jenkinsfile` of that repository describe how the test and tarball can be run and created respectively.
+The tarball can then be copied and committed into this repository.
+
+## Create a new version
+The version of the debian package is derived from the last entry in the `debian/changelog` file. The version of the last entry will determine the version of the debian package that will be created. You will also need to rename the tarball in the root with a matching version.
+
+The `debian/changelog` file has very strict formatting rules, so it's best to copy over an older entry and modify it.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppetdb (2.3.10-1puppetlabs1+xenial0+exo0) xenial; urgency=medium
+
+  * Improve fact retrieval performance.
+
+ -- Wouter Dullaert <wouter.dullaert@exoscale.ch>  Tue, 31 Mar 2020 14:40:00 +0100
+
 puppetdb (2.3.8-1puppetlabs1+xenial0+exo5) xenial; urgency=medium
 
   * Automatically restart on failure.


### PR DESCRIPTION
Updates the tarball with our performance fix.
Also adds a README with some pointers on how to build the tarball and update this repository.

This PR will create a 2.3.10 debian package once the jenkins job runs.